### PR TITLE
Fix docker command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A project boilerplate for Postgres, Express, React, Node, Typescript, Vite. This
 Assuming you already have docker installed.  
 
 On the projects root folder, execute the following commands:  
-`docker-compose build`  
-`docker-compose up`
+`docker compose build`  
+`docker compose up`
 
 ## Build for Production
 


### PR DESCRIPTION
If I run `docker-compose build` I get the error
```
➜  pern-ts-vite-boilerplate git:(master) docker-compose build
ERROR: Version "2.23.0" in "./docker-compose.yml" is invalid.
```
according to stackoverflow the correct command is `docker compose build`.

This PR fixes the command.